### PR TITLE
Adds Autocomplete IDE Helper

### DIFF
--- a/_laravel_ide_helper.php
+++ b/_laravel_ide_helper.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace Illuminate\Database\Eloquent
+{
+    use Closure;
+
+    if (false) {
+        class Builder
+        {
+            /**
+             * Add a relationship count / whereIn condition to the query.
+             *
+             * @param \Illuminate\Database\Eloquent\Relations\Relation|string $relation
+             * @param string                                                  $operator
+             * @param int                                                     $count
+             * @param string                                                  $boolean
+             * @param \Closure|null                                           $callback
+             *
+             * @throws \RuntimeException
+             *
+             * @return \Illuminate\Database\Eloquent\Builder|static
+             *
+             * @see \BiiiiiigMonster\Hasin\Database\Eloquent\BuilderMixin
+             */
+            public function hasIn($relation, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
+            {
+                return $this;
+            }
+
+            /**
+             * Add a relationship count / whereIn condition to the query with an "or".
+             *
+             * @param string $relation
+             * @param string $operator
+             * @param int    $count
+             *
+             * @return \Illuminate\Database\Eloquent\Builder|static
+             *
+             * @see \BiiiiiigMonster\Hasin\Database\Eloquent\BuilderMixin
+             */
+            public function orHasIn($relation, $operator = '>=', $count = 1)
+            {
+                return $this;
+            }
+
+            /**
+             * Add a relationship count / whereIn condition to the query.
+             *
+             * @param string        $relation
+             * @param string        $boolean
+             * @param \Closure|null $callback
+             *
+             * @return \Illuminate\Database\Eloquent\Builder|static
+             *
+             * @see \BiiiiiigMonster\Hasin\Database\Eloquent\BuilderMixin
+             */
+            public function doesntHaveIn($relation, $boolean = 'and', Closure $callback = null)
+            {
+                return $this;
+            }
+
+            /**
+             * Add a relationship count / whereIn condition to the query with where clauses.
+             *
+             * @param string        $relation
+             * @param \Closure|null $callback
+             * @param string        $operator
+             * @param int           $count
+             *
+             * @return \Illuminate\Database\Eloquent\Builder|static
+             *
+             * @see \BiiiiiigMonster\Hasin\Database\Eloquent\BuilderMixin
+             */
+            public function whereHasIn($relation, Closure $callback = null, $operator = '>=', $count = 1)
+            {
+                return $this;
+            }
+
+            /**
+             * Add a relationship count / whereIn condition to the query with where clauses and an "or".
+             *
+             * @param string        $relation
+             * @param \Closure|null $callback
+             * @param string        $operator
+             * @param int           $count
+             *
+             * @return \Illuminate\Database\Eloquent\Builder|static
+             *
+             * @see \BiiiiiigMonster\Hasin\Database\Eloquent\BuilderMixin
+             */
+            public function orWhereHasIn($relation, Closure $callback = null, $operator = '>=', $count = 1)
+            {
+                return $this;
+            }
+
+            /**
+             * Add a relationship count / whereIn condition to the query with where clauses.
+             *
+             * @param string        $relation
+             * @param \Closure|null $callback
+             *
+             * @return \Illuminate\Database\Eloquent\Builder|static
+             *
+             * @see \BiiiiiigMonster\Hasin\Database\Eloquent\BuilderMixin
+             */
+            public function whereDoesntHaveIn($relation, Closure $callback = null)
+            {
+                return $this;
+            }
+
+            /**
+             * Add a relationship count / whereIn condition to the query with where clauses and an "or".
+             *
+             * @param string        $relation
+             * @param \Closure|null $callback
+             *
+             * @return \Illuminate\Database\Eloquent\Builder|static
+             *
+             * @see \BiiiiiigMonster\Hasin\Database\Eloquent\BuilderMixin
+             */
+            public function orWhereDoesntHaveIn($relation, Closure $callback = null)
+            {
+                return $this;
+            }
+
+            /**
+             * Add a polymorphic relationship count / whereIn condition to the query.
+             *
+             * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+             * @param string|array                                           $types
+             * @param string                                                 $operator
+             * @param int                                                    $count
+             * @param string                                                 $boolean
+             * @param \Closure|null                                          $callback
+             *
+             * @return \Illuminate\Database\Eloquent\Builder|static
+             *
+             * @see \BiiiiiigMonster\Hasin\Database\Eloquent\BuilderMixin
+             */
+            public function hasMorphIn($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
+            {
+                return $this;
+            }
+
+            /**
+             * Add a polymorphic relationship count / whereIn condition to the query with an "or".
+             *
+             * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+             * @param string|array                                           $types
+             * @param string                                                 $operator
+             * @param int                                                    $count
+             *
+             * @return \Illuminate\Database\Eloquent\Builder|static
+             *
+             * @see \BiiiiiigMonster\Hasin\Database\Eloquent\BuilderMixin
+             */
+            public function orHasMorphIn($relation, $types, $operator = '>=', $count = 1)
+            {
+                return $this;
+            }
+
+            /**
+             * Add a polymorphic relationship count / whereIn condition to the query.
+             *
+             * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+             * @param string|array                                           $types
+             * @param string                                                 $boolean
+             * @param \Closure|null                                          $callback
+             *
+             * @return \Illuminate\Database\Eloquent\Builder|static
+             *
+             * @see \BiiiiiigMonster\Hasin\Database\Eloquent\BuilderMixin
+             */
+            public function doesntHaveMorphIn($relation, $types, $boolean = 'and', Closure $callback = null)
+            {
+                return $this;
+            }
+
+            /**
+             * Add a polymorphic relationship count / whereIn condition to the query with an "or".
+             *
+             * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+             * @param string|array                                           $types
+             *
+             * @return \Illuminate\Database\Eloquent\Builder|static
+             *
+             * @see \BiiiiiigMonster\Hasin\Database\Eloquent\BuilderMixin
+             */
+            public function orDoesntHaveMorphIn($relation, $types)
+            {
+                return $this;
+            }
+
+            /**
+             * Add a polymorphic relationship count / whereIn condition to the query with where clauses.
+             *
+             * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+             * @param string|array                                           $types
+             * @param \Closure|null                                          $callback
+             * @param string                                                 $operator
+             * @param int                                                    $count
+             *
+             * @return \Illuminate\Database\Eloquent\Builder|static
+             *
+             * @see \BiiiiiigMonster\Hasin\Database\Eloquent\BuilderMixin
+             */
+            public function orWhereHasMorphIn($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
+            {
+                return $this;
+            }
+
+            /**
+             * Add a polymorphic relationship count / whereIn condition to the query with where clauses.
+             *
+             * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+             * @param string|array                                           $types
+             * @param \Closure|null                                          $callback
+             *
+             * @return \Illuminate\Database\Eloquent\Builder|static
+             *
+             * @see \BiiiiiigMonster\Hasin\Database\Eloquent\BuilderMixin
+             */
+            public function whereDoesntHaveMorphIn($relation, $types, Closure $callback = null)
+            {
+                return $this;
+            }
+
+            /**
+             * Add a polymorphic relationship count / whereIn condition to the query with where clauses and an "or".
+             *
+             * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+             * @param string|array                                           $types
+             * @param \Closure|null                                          $callback
+             *
+             * @return \Illuminate\Database\Eloquent\Builder|static
+             *
+             * @see \BiiiiiigMonster\Hasin\Database\Eloquent\BuilderMixin
+             */
+            public function orWhereDoesntHaveMorphIn($relation, $types, Closure $callback = null)
+            {
+                return $this;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I would like to add additional IDE support to help support autocomplete when using this package.

A similar package to this one has added support for this.
https://github.com/mpyw/eloquent-has-by-non-dependent-subquery/blob/master/_laravel_ide_helper.php

This allows editors such as PHPStorm and Visual Studio Code to provide autocompletion for the method `orWhereHasIn` and `hasIn` on instances of `Builder`. This also helps with static analysis tools such as PHPStan.

**Example**:
![image](https://user-images.githubusercontent.com/2829285/132121567-75a7e070-20a5-44c0-a029-8cc40bc78fa2.png)

Original Issue: https://github.com/biiiiiigmonster/hasin/issues/2
